### PR TITLE
feat: implement ryan-astro-ping bot for message handling

### DIFF
--- a/src/ryan-astro-ping.ts
+++ b/src/ryan-astro-ping.ts
@@ -1,0 +1,36 @@
+import { Client, GatewayIntentBits, TextChannel } from 'discord.js';
+
+const client = new Client({
+  intents: [
+    GatewayIntentBits.Guilds,
+    GatewayIntentBits.GuildMessages,
+    GatewayIntentBits.MessageContent,
+  ],
+});
+
+const TOKEN = '';
+const USER_ID = '219283881390637056';
+const WATERCOOLER_CHANNEL_ID = '964903664265359433';
+
+client.on('messageCreate', async (message) => {
+  if (message.author.bot || message.author.id === USER_ID) return;
+
+  if (message.content.toLowerCase().includes('astro')) {
+    const targetChannel = client.channels.cache.get(
+      WATERCOOLER_CHANNEL_ID
+    ) as TextChannel;
+
+    if (!targetChannel) {
+      console.error('Target channel not found');
+      return;
+    }
+
+    const messageLink = `https://discord.com/channels/${message.guild?.id}/${message.channel.id}/${message.id}`;
+
+    await targetChannel.send(
+      `<@${USER_ID}>, your services as Astro Shill are required [here](${messageLink}).`
+    );
+  }
+});
+
+client.login(TOKEN);


### PR DESCRIPTION
I believe our resident Astro Shill needs something akin to Batman's Bat-Signal.

I put this together with the help of Discord's docs and AI, but I noticed none of the other bot features have the bot token in the `.ts` like this calling for. Since I don't have that, is there away around it that you have built in?