### PR TITLE
Add member verification and role auditing

### DIFF
--- a/src/__tests__/mockDiscordClient.ts
+++ b/src/__tests__/mockDiscordClient.ts
@@ -5,7 +5,10 @@ import type { Message, MessageReaction, User } from 'discord.js';
 
 let eventHandlers: Record<string, ((...args: any[]) => Promise<void>)[]> = {};
 
-export const mockDiscordChannel = { send: mock() };
+export const mockDiscordChannel = {
+  isTextBased: () => true,
+  send: mock(),
+};
 export const mockDiscordClient = {
   on: (event: string, handler: (...args: any[]) => Promise<void>) => {
     if (!eventHandlers[event]) {

--- a/src/__tests__/verification.test.ts
+++ b/src/__tests__/verification.test.ts
@@ -1,0 +1,316 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { Client, GuildMember, ThreadChannel } from 'discord.js';
+import {
+  assignUnverifiedRole,
+  registerVerificationListeners,
+  verifyIntroductionThreadCreator,
+} from '../verification';
+import {
+  mockDiscordChannel,
+  mockDiscordClient,
+  resetMockDiscordClient,
+} from './mockDiscordClient';
+
+const INTRODUCE_YOURSELF_CHANNEL_ID = '1157749239598821516';
+const VERIFIED_ROLE_ID = '1531700897623572700';
+const UNVERIFIED_ROLE_ID = '1532179332460576913';
+const ROLE_LOG_CHANNEL_ID = '1532182270209949758';
+
+function createMockMember({
+  isBot = false,
+  hasVerifiedRole = false,
+  hasUnverifiedRole = false,
+  addRoleError,
+  id = 'member123',
+}: {
+  isBot?: boolean;
+  hasVerifiedRole?: boolean;
+  hasUnverifiedRole?: boolean;
+  addRoleError?: Error;
+  id?: string;
+} = {}) {
+  const roleOperations: string[] = [];
+  const addRole = mock((roleId: string) => {
+    roleOperations.push(`add:${roleId}`);
+    if (addRoleError) return Promise.reject(addRoleError);
+    return Promise.resolve();
+  });
+  const removeRole = mock((roleId: string) => {
+    roleOperations.push(`remove:${roleId}`);
+    return Promise.resolve();
+  });
+  const member = {
+    id,
+    user: { bot: isBot },
+    guild: {
+      client: mockDiscordClient,
+    },
+    roles: {
+      cache: {
+        has: (roleId: string) =>
+          (roleId === VERIFIED_ROLE_ID && hasVerifiedRole) ||
+          (roleId === UNVERIFIED_ROLE_ID && hasUnverifiedRole),
+      },
+      add: addRole,
+      remove: removeRole,
+    },
+  } as unknown as GuildMember;
+
+  return { addRole, member, removeRole, roleOperations };
+}
+
+function createMockThread({
+  parentId = INTRODUCE_YOURSELF_CHANNEL_ID,
+  ownerId = 'member123',
+  isBot = false,
+  hasVerifiedRole = false,
+  hasUnverifiedRole = true,
+}: {
+  parentId?: string;
+  ownerId?: string | null;
+  isBot?: boolean;
+  hasVerifiedRole?: boolean;
+  hasUnverifiedRole?: boolean;
+} = {}) {
+  const { addRole, member, removeRole, roleOperations } = createMockMember({
+    isBot,
+    hasVerifiedRole,
+    hasUnverifiedRole,
+  });
+  const fetchMember = mock(() => Promise.resolve(member));
+  const thread = {
+    id: 'thread123',
+    parentId,
+    ownerId,
+    guild: {
+      members: {
+        fetch: fetchMember,
+      },
+    },
+  } as unknown as ThreadChannel;
+
+  return {
+    addRole,
+    fetchMember,
+    removeRole,
+    roleOperations,
+    thread,
+  };
+}
+
+describe('introduction verification', () => {
+  beforeEach(() => {
+    resetMockDiscordClient();
+  });
+
+  test('assigns the unverified role when a member joins', async () => {
+    const { addRole, member } = createMockMember();
+
+    const assigned = await assignUnverifiedRole(member);
+
+    expect(assigned).toBe(true);
+    expect(addRole).toHaveBeenCalledWith(
+      UNVERIFIED_ROLE_ID,
+      'Joined the server'
+    );
+  });
+
+  test('does not assign the unverified role to bots', async () => {
+    const { addRole, member } = createMockMember({ isBot: true });
+
+    const assigned = await assignUnverifiedRole(member);
+
+    expect(assigned).toBe(false);
+    expect(addRole).not.toHaveBeenCalled();
+  });
+
+  test('does not assign unverified to an already verified member', async () => {
+    const { addRole, member } = createMockMember({ hasVerifiedRole: true });
+
+    const assigned = await assignUnverifiedRole(member);
+
+    expect(assigned).toBe(false);
+    expect(addRole).not.toHaveBeenCalled();
+  });
+
+  test('reports a failed unverified role assignment', async () => {
+    const { member } = createMockMember({
+      addRoleError: new Error('Missing Permissions'),
+    });
+
+    await expect(assignUnverifiedRole(member)).rejects.toThrow(
+      'Missing Permissions'
+    );
+
+    expect(mockDiscordClient.channels.fetch).toHaveBeenCalledWith(
+      ROLE_LOG_CHANNEL_ID
+    );
+    expect(mockDiscordChannel.send).toHaveBeenCalledWith({
+      content: `❌ Failed to add <@&${UNVERIFIED_ROLE_ID}> to <@member123>: Missing Permissions`,
+      allowedMentions: { parse: [] },
+    });
+  });
+
+  test('replaces unverified with verified for an introduction thread creator', async () => {
+    const { addRole, fetchMember, removeRole, roleOperations, thread } =
+      createMockThread();
+
+    const assigned = await verifyIntroductionThreadCreator(thread);
+
+    expect(assigned).toBe(true);
+    expect(fetchMember).toHaveBeenCalledWith('member123');
+    expect(addRole).toHaveBeenCalledWith(
+      VERIFIED_ROLE_ID,
+      'Created a thread in the introduce-yourself channel'
+    );
+    expect(removeRole).toHaveBeenCalledWith(
+      UNVERIFIED_ROLE_ID,
+      'Completed introduction by creating a thread'
+    );
+    expect(roleOperations).toEqual([
+      `add:${VERIFIED_ROLE_ID}`,
+      `remove:${UNVERIFIED_ROLE_ID}`,
+    ]);
+  });
+
+  test('ignores threads created outside the introduction channel', async () => {
+    const { addRole, fetchMember, removeRole, thread } = createMockThread({
+      parentId: 'another-channel',
+    });
+
+    const assigned = await verifyIntroductionThreadCreator(thread);
+
+    expect(assigned).toBe(false);
+    expect(fetchMember).not.toHaveBeenCalled();
+    expect(addRole).not.toHaveBeenCalled();
+    expect(removeRole).not.toHaveBeenCalled();
+  });
+
+  test('ignores threads without a creator', async () => {
+    const { addRole, fetchMember, removeRole, thread } = createMockThread({
+      ownerId: null,
+    });
+
+    const assigned = await verifyIntroductionThreadCreator(thread);
+
+    expect(assigned).toBe(false);
+    expect(fetchMember).not.toHaveBeenCalled();
+    expect(addRole).not.toHaveBeenCalled();
+    expect(removeRole).not.toHaveBeenCalled();
+  });
+
+  test('only removes unverified from an already verified member', async () => {
+    const { addRole, fetchMember, removeRole, thread } = createMockThread({
+      hasVerifiedRole: true,
+    });
+
+    const updated = await verifyIntroductionThreadCreator(thread);
+
+    expect(updated).toBe(true);
+    expect(fetchMember).toHaveBeenCalledWith('member123');
+    expect(addRole).not.toHaveBeenCalled();
+    expect(removeRole).toHaveBeenCalledWith(
+      UNVERIFIED_ROLE_ID,
+      'Completed introduction by creating a thread'
+    );
+  });
+
+  test('does nothing when the member is already fully verified', async () => {
+    const { addRole, removeRole, thread } = createMockThread({
+      hasVerifiedRole: true,
+      hasUnverifiedRole: false,
+    });
+
+    const updated = await verifyIntroductionThreadCreator(thread);
+
+    expect(updated).toBe(false);
+    expect(addRole).not.toHaveBeenCalled();
+    expect(removeRole).not.toHaveBeenCalled();
+  });
+
+  test('does not assign the role to bots', async () => {
+    const { addRole, removeRole, thread } = createMockThread({ isBot: true });
+
+    const assigned = await verifyIntroductionThreadCreator(thread);
+
+    expect(assigned).toBe(false);
+    expect(addRole).not.toHaveBeenCalled();
+    expect(removeRole).not.toHaveBeenCalled();
+  });
+
+  test('registers a member-join listener', async () => {
+    const { addRole, member } = createMockMember();
+    registerVerificationListeners(mockDiscordClient as unknown as Client);
+
+    const handled = await mockDiscordClient.emit('guildMemberAdd', member);
+
+    expect(handled).toBe(true);
+    expect(addRole).toHaveBeenCalledWith(
+      UNVERIFIED_ROLE_ID,
+      'Joined the server'
+    );
+  });
+
+  test('logs when a tracked role is gained', async () => {
+    const { member: oldMember } = createMockMember();
+    const { member: newMember } = createMockMember({
+      hasVerifiedRole: true,
+    });
+    registerVerificationListeners(mockDiscordClient as unknown as Client);
+
+    await mockDiscordClient.emit('guildMemberUpdate', oldMember, newMember);
+
+    expect(mockDiscordClient.channels.fetch).toHaveBeenCalledWith(
+      ROLE_LOG_CHANNEL_ID
+    );
+    expect(mockDiscordChannel.send).toHaveBeenCalledWith({
+      content: `<@member123> gained the <@&${VERIFIED_ROLE_ID}> role (verified).`,
+      allowedMentions: { parse: [] },
+    });
+  });
+
+  test('logs when a tracked role is lost', async () => {
+    const { member: oldMember } = createMockMember({
+      hasUnverifiedRole: true,
+    });
+    const { member: newMember } = createMockMember();
+    registerVerificationListeners(mockDiscordClient as unknown as Client);
+
+    await mockDiscordClient.emit('guildMemberUpdate', oldMember, newMember);
+
+    expect(mockDiscordChannel.send).toHaveBeenCalledWith({
+      content: `<@member123> lost the <@&${UNVERIFIED_ROLE_ID}> role (unverified).`,
+      allowedMentions: { parse: [] },
+    });
+  });
+
+  test('does not log member updates without tracked role changes', async () => {
+    const { member: oldMember } = createMockMember();
+    const { member: newMember } = createMockMember();
+    registerVerificationListeners(mockDiscordClient as unknown as Client);
+
+    await mockDiscordClient.emit('guildMemberUpdate', oldMember, newMember);
+
+    expect(mockDiscordClient.channels.fetch).not.toHaveBeenCalled();
+    expect(mockDiscordChannel.send).not.toHaveBeenCalled();
+  });
+
+  test('registers a thread-create listener', async () => {
+    const { addRole, thread } = createMockThread();
+    registerVerificationListeners(mockDiscordClient as unknown as Client);
+
+    const handled = await mockDiscordClient.emit('threadCreate', thread, true);
+
+    expect(handled).toBe(true);
+    expect(addRole).toHaveBeenCalledTimes(1);
+  });
+
+  test('ignores an existing thread when the bot gains access to it', async () => {
+    const { addRole, thread } = createMockThread();
+    registerVerificationListeners(mockDiscordClient as unknown as Client);
+
+    await mockDiscordClient.emit('threadCreate', thread, false);
+
+    expect(addRole).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/verification.test.ts
+++ b/src/__tests__/verification.test.ts
@@ -1,9 +1,8 @@
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
-import type { Client, GuildMember, ThreadChannel } from 'discord.js';
+import type { Client, GuildMember } from 'discord.js';
 import {
   assignUnverifiedRole,
   registerVerificationListeners,
-  verifyIntroductionThreadCreator,
 } from '../verification';
 import {
   mockDiscordChannel,
@@ -11,7 +10,6 @@ import {
   resetMockDiscordClient,
 } from './mockDiscordClient';
 
-const INTRODUCE_YOURSELF_CHANNEL_ID = '1157749239598821516';
 const VERIFIED_ROLE_ID = '1531700897623572700';
 const UNVERIFIED_ROLE_ID = '1532179332460576913';
 const ROLE_LOG_CHANNEL_ID = '1532182270209949758';
@@ -29,14 +27,8 @@ function createMockMember({
   addRoleError?: Error;
   id?: string;
 } = {}) {
-  const roleOperations: string[] = [];
-  const addRole = mock((roleId: string) => {
-    roleOperations.push(`add:${roleId}`);
+  const addRole = mock((_roleId: string) => {
     if (addRoleError) return Promise.reject(addRoleError);
-    return Promise.resolve();
-  });
-  const removeRole = mock((roleId: string) => {
-    roleOperations.push(`remove:${roleId}`);
     return Promise.resolve();
   });
   const member = {
@@ -52,53 +44,13 @@ function createMockMember({
           (roleId === UNVERIFIED_ROLE_ID && hasUnverifiedRole),
       },
       add: addRole,
-      remove: removeRole,
     },
   } as unknown as GuildMember;
 
-  return { addRole, member, removeRole, roleOperations };
+  return { addRole, member };
 }
 
-function createMockThread({
-  parentId = INTRODUCE_YOURSELF_CHANNEL_ID,
-  ownerId = 'member123',
-  isBot = false,
-  hasVerifiedRole = false,
-  hasUnverifiedRole = true,
-}: {
-  parentId?: string;
-  ownerId?: string | null;
-  isBot?: boolean;
-  hasVerifiedRole?: boolean;
-  hasUnverifiedRole?: boolean;
-} = {}) {
-  const { addRole, member, removeRole, roleOperations } = createMockMember({
-    isBot,
-    hasVerifiedRole,
-    hasUnverifiedRole,
-  });
-  const fetchMember = mock(() => Promise.resolve(member));
-  const thread = {
-    id: 'thread123',
-    parentId,
-    ownerId,
-    guild: {
-      members: {
-        fetch: fetchMember,
-      },
-    },
-  } as unknown as ThreadChannel;
-
-  return {
-    addRole,
-    fetchMember,
-    removeRole,
-    roleOperations,
-    thread,
-  };
-}
-
-describe('introduction verification', () => {
+describe('member role management', () => {
   beforeEach(() => {
     resetMockDiscordClient();
   });
@@ -149,93 +101,6 @@ describe('introduction verification', () => {
       content: `❌ Failed to add <@&${UNVERIFIED_ROLE_ID}> to <@member123>: Missing Permissions`,
       allowedMentions: { parse: [] },
     });
-  });
-
-  test('replaces unverified with verified for an introduction thread creator', async () => {
-    const { addRole, fetchMember, removeRole, roleOperations, thread } =
-      createMockThread();
-
-    const assigned = await verifyIntroductionThreadCreator(thread);
-
-    expect(assigned).toBe(true);
-    expect(fetchMember).toHaveBeenCalledWith('member123');
-    expect(addRole).toHaveBeenCalledWith(
-      VERIFIED_ROLE_ID,
-      'Created a thread in the introduce-yourself channel'
-    );
-    expect(removeRole).toHaveBeenCalledWith(
-      UNVERIFIED_ROLE_ID,
-      'Completed introduction by creating a thread'
-    );
-    expect(roleOperations).toEqual([
-      `add:${VERIFIED_ROLE_ID}`,
-      `remove:${UNVERIFIED_ROLE_ID}`,
-    ]);
-  });
-
-  test('ignores threads created outside the introduction channel', async () => {
-    const { addRole, fetchMember, removeRole, thread } = createMockThread({
-      parentId: 'another-channel',
-    });
-
-    const assigned = await verifyIntroductionThreadCreator(thread);
-
-    expect(assigned).toBe(false);
-    expect(fetchMember).not.toHaveBeenCalled();
-    expect(addRole).not.toHaveBeenCalled();
-    expect(removeRole).not.toHaveBeenCalled();
-  });
-
-  test('ignores threads without a creator', async () => {
-    const { addRole, fetchMember, removeRole, thread } = createMockThread({
-      ownerId: null,
-    });
-
-    const assigned = await verifyIntroductionThreadCreator(thread);
-
-    expect(assigned).toBe(false);
-    expect(fetchMember).not.toHaveBeenCalled();
-    expect(addRole).not.toHaveBeenCalled();
-    expect(removeRole).not.toHaveBeenCalled();
-  });
-
-  test('only removes unverified from an already verified member', async () => {
-    const { addRole, fetchMember, removeRole, thread } = createMockThread({
-      hasVerifiedRole: true,
-    });
-
-    const updated = await verifyIntroductionThreadCreator(thread);
-
-    expect(updated).toBe(true);
-    expect(fetchMember).toHaveBeenCalledWith('member123');
-    expect(addRole).not.toHaveBeenCalled();
-    expect(removeRole).toHaveBeenCalledWith(
-      UNVERIFIED_ROLE_ID,
-      'Completed introduction by creating a thread'
-    );
-  });
-
-  test('does nothing when the member is already fully verified', async () => {
-    const { addRole, removeRole, thread } = createMockThread({
-      hasVerifiedRole: true,
-      hasUnverifiedRole: false,
-    });
-
-    const updated = await verifyIntroductionThreadCreator(thread);
-
-    expect(updated).toBe(false);
-    expect(addRole).not.toHaveBeenCalled();
-    expect(removeRole).not.toHaveBeenCalled();
-  });
-
-  test('does not assign the role to bots', async () => {
-    const { addRole, removeRole, thread } = createMockThread({ isBot: true });
-
-    const assigned = await verifyIntroductionThreadCreator(thread);
-
-    expect(assigned).toBe(false);
-    expect(addRole).not.toHaveBeenCalled();
-    expect(removeRole).not.toHaveBeenCalled();
   });
 
   test('registers a member-join listener', async () => {
@@ -295,22 +160,11 @@ describe('introduction verification', () => {
     expect(mockDiscordChannel.send).not.toHaveBeenCalled();
   });
 
-  test('registers a thread-create listener', async () => {
-    const { addRole, thread } = createMockThread();
+  test('does not register thread-based verification automation', async () => {
     registerVerificationListeners(mockDiscordClient as unknown as Client);
 
-    const handled = await mockDiscordClient.emit('threadCreate', thread, true);
+    const handled = await mockDiscordClient.emit('threadCreate', {});
 
-    expect(handled).toBe(true);
-    expect(addRole).toHaveBeenCalledTimes(1);
-  });
-
-  test('ignores an existing thread when the bot gains access to it', async () => {
-    const { addRole, thread } = createMockThread();
-    registerVerificationListeners(mockDiscordClient as unknown as Client);
-
-    await mockDiscordClient.emit('threadCreate', thread, false);
-
-    expect(addRole).not.toHaveBeenCalled();
+    expect(handled).toBe(false);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import { handleCommand as handleTwitchCommand } from './twitch';
 import { handleGoalsCommand, handleGoalInteraction } from './goals';
 import { registerAcronymListeners } from './acronyms';
 import { registerHaikuListeners } from './haiku';
+import { registerVerificationListeners } from './verification';
 
 const client = new Client({
   intents: [
@@ -50,6 +51,7 @@ client.once('ready', async () => {
   registerKudosListeners(client);
   registerAcronymListeners(client);
   registerHaikuListeners(client);
+  registerVerificationListeners(client);
   registerBookClubPicksCron(client);
   startWebhookServer({
     client,

--- a/src/verification.ts
+++ b/src/verification.ts
@@ -1,0 +1,185 @@
+import { Client, Events, GuildMember, ThreadChannel } from 'discord.js';
+import { logger } from './logger';
+
+const INTRODUCE_YOURSELF_CHANNEL_ID = '1157749239598821516';
+const VERIFIED_ROLE_ID = '1531700897623572700';
+const UNVERIFIED_ROLE_ID = '1532179332460576913';
+const ROLE_LOG_CHANNEL_ID = '1532182270209949758';
+const TRACKED_ROLES = [
+  { id: VERIFIED_ROLE_ID, name: 'verified' },
+  { id: UNVERIFIED_ROLE_ID, name: 'unverified' },
+];
+
+async function sendRoleLog(client: Client, content: string): Promise<void> {
+  const channel = await client.channels.fetch(ROLE_LOG_CHANNEL_ID);
+
+  if (!channel?.isTextBased() || !('send' in channel)) {
+    throw new Error('Role log channel is not a text-based channel');
+  }
+
+  await channel.send({
+    content,
+    allowedMentions: { parse: [] },
+  });
+}
+
+async function reportRoleChangeFailure({
+  member,
+  action,
+  roleId,
+  error,
+}: {
+  member: GuildMember;
+  action: 'add' | 'remove';
+  roleId: string;
+  error: unknown;
+}): Promise<void> {
+  const actionDescription =
+    action === 'add' ? `add <@&${roleId}> to` : `remove <@&${roleId}> from`;
+  const errorMessage =
+    error instanceof Error ? error.message : 'Unknown Discord API error';
+
+  try {
+    await sendRoleLog(
+      member.guild.client,
+      `❌ Failed to ${actionDescription} <@${member.id}>: ${errorMessage.slice(0, 500)}`
+    );
+  } catch (logError) {
+    logger.error(logError, 'Error sending role assignment failure log');
+  }
+}
+
+async function changeMemberRole({
+  member,
+  action,
+  roleId,
+  reason,
+}: {
+  member: GuildMember;
+  action: 'add' | 'remove';
+  roleId: string;
+  reason: string;
+}): Promise<void> {
+  try {
+    await member.roles[action](roleId, reason);
+  } catch (error) {
+    await reportRoleChangeFailure({ member, action, roleId, error });
+    throw error;
+  }
+}
+
+export async function assignUnverifiedRole(
+  member: GuildMember
+): Promise<boolean> {
+  if (
+    member.user.bot ||
+    member.roles.cache.has(UNVERIFIED_ROLE_ID) ||
+    member.roles.cache.has(VERIFIED_ROLE_ID)
+  ) {
+    return false;
+  }
+
+  await changeMemberRole({
+    member,
+    action: 'add',
+    roleId: UNVERIFIED_ROLE_ID,
+    reason: 'Joined the server',
+  });
+
+  logger.info(
+    { memberId: member.id },
+    'Assigned unverified role to new member'
+  );
+
+  return true;
+}
+
+export async function verifyIntroductionThreadCreator(
+  thread: ThreadChannel
+): Promise<boolean> {
+  if (thread.parentId !== INTRODUCE_YOURSELF_CHANNEL_ID || !thread.ownerId) {
+    return false;
+  }
+
+  const member = await thread.guild.members.fetch(thread.ownerId);
+
+  if (member.user.bot) {
+    return false;
+  }
+
+  const needsVerifiedRole = !member.roles.cache.has(VERIFIED_ROLE_ID);
+  const hasUnverifiedRole = member.roles.cache.has(UNVERIFIED_ROLE_ID);
+
+  if (!needsVerifiedRole && !hasUnverifiedRole) {
+    return false;
+  }
+
+  if (needsVerifiedRole) {
+    await changeMemberRole({
+      member,
+      action: 'add',
+      roleId: VERIFIED_ROLE_ID,
+      reason: 'Created a thread in the introduce-yourself channel',
+    });
+  }
+
+  if (hasUnverifiedRole) {
+    await changeMemberRole({
+      member,
+      action: 'remove',
+      roleId: UNVERIFIED_ROLE_ID,
+      reason: 'Completed introduction by creating a thread',
+    });
+  }
+
+  logger.info(
+    {
+      memberId: member.id,
+      threadId: thread.id,
+    },
+    'Updated roles for introduction thread creator'
+  );
+
+  return true;
+}
+
+export function registerVerificationListeners(client: Client) {
+  client.on(Events.GuildMemberUpdate, async (oldMember, newMember) => {
+    try {
+      for (const role of TRACKED_ROLES) {
+        const hadRole = oldMember.roles.cache.has(role.id);
+        const hasRole = newMember.roles.cache.has(role.id);
+
+        if (hadRole === hasRole) continue;
+
+        const change = hasRole ? 'gained' : 'lost';
+        await sendRoleLog(
+          client,
+          `<@${newMember.id}> ${change} the <@&${role.id}> role (${role.name}).`
+        );
+      }
+    } catch (error) {
+      logger.error(error, 'Error sending role change log');
+    }
+  });
+
+  client.on(Events.GuildMemberAdd, async (member) => {
+    try {
+      await assignUnverifiedRole(member);
+    } catch (error) {
+      logger.error(error, 'Error assigning unverified role to new member');
+    }
+  });
+
+  client.on(Events.ThreadCreate, async (thread, newlyCreated) => {
+    if (!newlyCreated) return;
+
+    try {
+      await verifyIntroductionThreadCreator(thread);
+    } catch (error) {
+      logger.error(error, 'Error verifying introduction thread creator');
+    }
+  });
+
+  logger.info('Verification listeners registered');
+}

--- a/src/verification.ts
+++ b/src/verification.ts
@@ -1,7 +1,6 @@
-import { Client, Events, GuildMember, ThreadChannel } from 'discord.js';
+import { Client, Events, GuildMember } from 'discord.js';
 import { logger } from './logger';
 
-const INTRODUCE_YOURSELF_CHANNEL_ID = '1157749239598821516';
 const VERIFIED_ROLE_ID = '1531700897623572700';
 const UNVERIFIED_ROLE_ID = '1532179332460576913';
 const ROLE_LOG_CHANNEL_ID = '1532182270209949758';
@@ -23,47 +22,41 @@ async function sendRoleLog(client: Client, content: string): Promise<void> {
   });
 }
 
-async function reportRoleChangeFailure({
+async function reportRoleAssignmentFailure({
   member,
-  action,
   roleId,
   error,
 }: {
   member: GuildMember;
-  action: 'add' | 'remove';
   roleId: string;
   error: unknown;
 }): Promise<void> {
-  const actionDescription =
-    action === 'add' ? `add <@&${roleId}> to` : `remove <@&${roleId}> from`;
   const errorMessage =
     error instanceof Error ? error.message : 'Unknown Discord API error';
 
   try {
     await sendRoleLog(
       member.guild.client,
-      `❌ Failed to ${actionDescription} <@${member.id}>: ${errorMessage.slice(0, 500)}`
+      `❌ Failed to add <@&${roleId}> to <@${member.id}>: ${errorMessage.slice(0, 500)}`
     );
   } catch (logError) {
     logger.error(logError, 'Error sending role assignment failure log');
   }
 }
 
-async function changeMemberRole({
+async function addMemberRole({
   member,
-  action,
   roleId,
   reason,
 }: {
   member: GuildMember;
-  action: 'add' | 'remove';
   roleId: string;
   reason: string;
 }): Promise<void> {
   try {
-    await member.roles[action](roleId, reason);
+    await member.roles.add(roleId, reason);
   } catch (error) {
-    await reportRoleChangeFailure({ member, action, roleId, error });
+    await reportRoleAssignmentFailure({ member, roleId, error });
     throw error;
   }
 }
@@ -79,9 +72,8 @@ export async function assignUnverifiedRole(
     return false;
   }
 
-  await changeMemberRole({
+  await addMemberRole({
     member,
-    action: 'add',
     roleId: UNVERIFIED_ROLE_ID,
     reason: 'Joined the server',
   });
@@ -89,55 +81,6 @@ export async function assignUnverifiedRole(
   logger.info(
     { memberId: member.id },
     'Assigned unverified role to new member'
-  );
-
-  return true;
-}
-
-export async function verifyIntroductionThreadCreator(
-  thread: ThreadChannel
-): Promise<boolean> {
-  if (thread.parentId !== INTRODUCE_YOURSELF_CHANNEL_ID || !thread.ownerId) {
-    return false;
-  }
-
-  const member = await thread.guild.members.fetch(thread.ownerId);
-
-  if (member.user.bot) {
-    return false;
-  }
-
-  const needsVerifiedRole = !member.roles.cache.has(VERIFIED_ROLE_ID);
-  const hasUnverifiedRole = member.roles.cache.has(UNVERIFIED_ROLE_ID);
-
-  if (!needsVerifiedRole && !hasUnverifiedRole) {
-    return false;
-  }
-
-  if (needsVerifiedRole) {
-    await changeMemberRole({
-      member,
-      action: 'add',
-      roleId: VERIFIED_ROLE_ID,
-      reason: 'Created a thread in the introduce-yourself channel',
-    });
-  }
-
-  if (hasUnverifiedRole) {
-    await changeMemberRole({
-      member,
-      action: 'remove',
-      roleId: UNVERIFIED_ROLE_ID,
-      reason: 'Completed introduction by creating a thread',
-    });
-  }
-
-  logger.info(
-    {
-      memberId: member.id,
-      threadId: thread.id,
-    },
-    'Updated roles for introduction thread creator'
   );
 
   return true;
@@ -168,16 +111,6 @@ export function registerVerificationListeners(client: Client) {
       await assignUnverifiedRole(member);
     } catch (error) {
       logger.error(error, 'Error assigning unverified role to new member');
-    }
-  });
-
-  client.on(Events.ThreadCreate, async (thread, newlyCreated) => {
-    if (!newlyCreated) return;
-
-    try {
-      await verifyIntroductionThreadCreator(thread);
-    } catch (error) {
-      logger.error(error, 'Error verifying introduction thread creator');
     }
   });
 


### PR DESCRIPTION
new server members are granted the `unverified` role by LGTBot

we must manually verify them

also added auditing of LGTBots actions surrounding role assignment