### PR TITLE
Emoji Migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,9 @@ All commands are under the `/lgt` prefix with the following structure:
     ├── subscribe <username>   # Subscribe to Twitch channel
     ├── unsubscribe <username> # Unsubscribe from channel
     └── list                   # List all subscriptions
+└── symbols (mod only)
+    ├── import-from <server-id> # Imports emojis from other server
+    ├── remove <emoji>          # Remove an emoji from server
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -37,6 +37,17 @@ A Discord bot for the Let's Get Technical community that provides community enga
 
 - Custom reply system for specific users in the watercooler channel
 
+### 5. Emoji Transfers
+
+- Manages server emojis (import from another server, remove from your own server)
+- Requires:
+  - Moderator Permissions for the target server (server receiving emojis)
+  - Manage Expressions Permission for the bot in the target server
+  - Bot membership in the source server (server supplying emojis)
+- Features:
+  - `/lgt symbols import-from <server-id>`: Import all custom emojis from <server-id>
+  - `/lgt symbols remove <emoji>`: Remove <emoji> from server
+
 ## Technical Stack
 
 - **Runtime**: [Bun](https://bun.sh)

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -4,6 +4,7 @@ import { getKudosCommands } from './kudos';
 import { getBookClubPicksCommands } from './book-club-picks';
 import { getTwitchCommands } from './twitch';
 import { getGoalsCommands } from './goals';
+import { getEmojiCommands } from './emoji';
 
 const lgtCommand = new SlashCommandBuilder()
   .setName('lgt')
@@ -27,7 +28,8 @@ const commands = [
       return group;
     })
     .addSubcommandGroup(getTwitchCommands())
-    .addSubcommandGroup(getGoalsCommands()),
+    .addSubcommandGroup(getGoalsCommands())
+    .addSubcommandGroup(getEmojiCommands()),
 ];
 
 export async function registerCommands() {

--- a/src/emoji.ts
+++ b/src/emoji.ts
@@ -1,0 +1,240 @@
+import {
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  Colors,
+  DiscordAPIError,
+  EmbedBuilder,
+  SlashCommandSubcommandGroupBuilder,
+} from 'discord.js';
+import { logger } from './logger';
+
+const MAX_EMOJIS_CODE = 30008;
+
+export function getEmojiCommands() {
+  return (group: SlashCommandSubcommandGroupBuilder) =>
+    group
+      .setName('symbols')
+      .setDescription('Symbol management commands')
+      .addSubcommand((sub) =>
+        sub
+          .setName('import-from')
+          .setDescription('Import symbols from another server this bot is in')
+          .addStringOption((opt) =>
+            opt
+              .setName('server-id')
+              .setDescription('The ID of the server to import symbols from')
+              .setRequired(true)
+          )
+      )
+      .addSubcommand((sub) =>
+        sub
+          .setName('remove')
+          .setDescription('Remove a symbol from this server')
+          .addStringOption((opt) =>
+            opt
+              .setName('symbol')
+              .setDescription('The symbol to remove')
+              .setRequired(true)
+              .setAutocomplete(true)
+          )
+      );
+}
+
+export async function handleEmojiCommand(
+  interaction: ChatInputCommandInteraction
+) {
+  const subcommand = interaction.options.getSubcommand();
+  switch (subcommand) {
+    case 'import-from':
+      await handleCloneFrom(interaction);
+      break;
+    case 'remove':
+      await handleRemove(interaction);
+      break;
+  }
+}
+
+export async function handleEmojiAutocomplete(
+  interaction: AutocompleteInteraction
+) {
+  const focused = interaction.options.getFocused().toLowerCase();
+  const emojis = await interaction.guild!.emojis.fetch();
+
+  const choices = emojis
+    .filter(
+      (e) => !focused || (e.name?.toLowerCase().includes(focused) ?? false)
+    )
+    .first(25)
+    .map((e) => ({
+      name: `:${e.name}:`,
+      value: e.id,
+    }));
+
+  await interaction.respond(choices);
+}
+
+async function handleCloneFrom(interaction: ChatInputCommandInteraction) {
+  await interaction.deferReply();
+
+  const sourceGuildId = interaction.options.getString('server-id')!;
+  const targetGuild = interaction.guild!;
+
+  let sourceGuild;
+  try {
+    sourceGuild = await interaction.client.guilds.fetch(sourceGuildId);
+  } catch {
+    await interaction.editReply({
+      embeds: [
+        new EmbedBuilder()
+          .setTitle('Unknown server')
+          .setColor(Colors.DarkRed)
+          .setDescription("I'm not a member of that server.")
+          .setTimestamp(),
+      ],
+    });
+    return;
+  }
+
+  const [sourceEmojis, targetEmojis] = await Promise.all([
+    sourceGuild.emojis.fetch(),
+    targetGuild.emojis.fetch(),
+  ]);
+
+  const targetEmojiNames = new Set(
+    targetEmojis
+      .map((e) => e.name)
+      .filter((name): name is string => name !== null)
+  );
+
+  const duplicates: string[] = [];
+  const toClone = [];
+  for (const emoji of sourceEmojis.values()) {
+    if (emoji.name && targetEmojiNames.has(emoji.name)) {
+      duplicates.push(emoji.name);
+    } else {
+      toClone.push(emoji);
+    }
+  }
+
+  if (toClone.length === 0) {
+    const description =
+      duplicates.length === 0
+        ? `**${sourceGuild.name}** has no custom symbols.`
+        : `All symbols from **${sourceGuild.name}** already exist in this server.`;
+    await interaction.editReply({
+      embeds: [
+        new EmbedBuilder()
+          .setColor(Colors.DarkGold)
+          .setTitle('Nothing to import')
+          .setDescription(description)
+          .setTimestamp(),
+      ],
+    });
+    return;
+  }
+
+  await interaction.editReply({
+    embeds: [
+      new EmbedBuilder()
+        .setColor(Colors.DarkGold)
+        .setTitle('Importing symbols...')
+        .setDescription(
+          `Processing **${toClone.length}** symbol(s) from **${sourceGuild.name}**`
+        )
+        .setTimestamp(),
+    ],
+  });
+
+  let transferred = 0;
+  const failed: string[] = [];
+
+  for (const emoji of toClone) {
+    const imageUrl = emoji.imageURL();
+    if (!imageUrl) {
+      failed.push(emoji.name ?? emoji.id);
+      continue;
+    }
+
+    try {
+      await targetGuild.emojis.create({
+        attachment: imageUrl,
+        name: emoji.name!,
+      });
+      transferred++;
+    } catch (error) {
+      const name = emoji.name ?? emoji.id;
+      if (error instanceof DiscordAPIError && error.code === MAX_EMOJIS_CODE) {
+        failed.push(name);
+        break;
+      }
+      logger.error(error, `Failed to import symbol ${name}`);
+      failed.push(name);
+    }
+  }
+
+  const fields = [];
+  if (duplicates.length > 0) {
+    fields.push({
+      name: `Skipped — ${duplicates.length} duplicate${duplicates.length === 1 ? '' : 's'}`,
+      value: duplicates.join(' • '),
+    });
+  }
+  if (failed.length > 0) {
+    fields.push({
+      name: `Failed — ${failed.length}`,
+      value: failed.join(' • '),
+    });
+  }
+
+  const allFailed = transferred === 0 && failed.length > 0;
+  const embed = new EmbedBuilder()
+    .setColor(allFailed ? Colors.DarkRed : Colors.DarkGreen)
+    .setTitle(allFailed ? 'Import failed' : 'Symbols imported!')
+    .setDescription(
+      `Imported **${transferred}** symbol(s) from **${sourceGuild.name}**`
+    )
+    .setTimestamp();
+
+  if (fields.length > 0) embed.addFields(fields);
+
+  await interaction.editReply({ embeds: [embed] });
+}
+
+async function handleRemove(interaction: ChatInputCommandInteraction) {
+  const emojiValue = interaction.options.getString('symbol')!;
+  const guild = interaction.guild!;
+
+  const allEmojis = await guild.emojis.fetch();
+
+  // compare against names instead of id's, protect against mid-command-entry navigation
+  const cleanName = emojiValue.replace(/^:+|:+$/g, '');
+  const emoji =
+    allEmojis.get(emojiValue) ?? allEmojis.find((e) => e.name === cleanName);
+
+  if (!emoji) {
+    await interaction.reply({
+      embeds: [
+        new EmbedBuilder()
+          .setTitle('Not found')
+          .setColor(Colors.DarkRed)
+          .setDescription("That symbol doesn't exist in this server.")
+          .setTimestamp(),
+      ],
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const name = emoji.name ?? emojiValue;
+  await emoji.delete();
+
+  await interaction.reply({
+    embeds: [
+      new EmbedBuilder()
+        .setTitle('Symbol removed')
+        .setColor(Colors.DarkGreen)
+        .setDescription(`**${name}** has been removed.`)
+        .setTimestamp(),
+    ],
+  });
+}

--- a/src/emoji.ts
+++ b/src/emoji.ts
@@ -25,6 +25,14 @@ export function getEmojiCommands() {
               .setDescription('The ID of the server to import symbols from')
               .setRequired(true)
           )
+          .addStringOption((opt) =>
+            opt
+              .setName('emoji-name')
+              .setDescription(
+                'Name of a specific symbol to import (imports all if omitted)'
+              )
+              .setRequired(false)
+          )
       )
       .addSubcommand((sub) =>
         sub
@@ -114,6 +122,41 @@ async function handleCloneFrom(interaction: ChatInputCommandInteraction) {
     } else {
       toClone.push(emoji);
     }
+  }
+
+  const targetName = interaction.options.getString('emoji-name');
+  if (targetName) {
+    const match = sourceEmojis.find(
+      (e) => e.name?.toLowerCase() === targetName.toLowerCase()
+    );
+    if (!match) {
+      await interaction.editReply({
+        embeds: [
+          new EmbedBuilder()
+            .setColor(Colors.DarkRed)
+            .setTitle('Symbol not found')
+            .setDescription(
+              `**${targetName}** doesn't exist in **${sourceGuild.name}**.`
+            )
+            .setTimestamp(),
+        ],
+      });
+      return;
+    }
+    if (duplicates.includes(match.name!)) {
+      await interaction.editReply({
+        embeds: [
+          new EmbedBuilder()
+            .setColor(Colors.DarkGold)
+            .setTitle('Already exists')
+            .setDescription(`**${match.name}** already exists in this server.`)
+            .setTimestamp(),
+        ],
+      });
+      return;
+    }
+    toClone.splice(0, toClone.length, match);
+    duplicates.length = 0;
   }
 
   if (toClone.length === 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
 } from './kudos';
 import { handleCommand as handleTwitchCommand } from './twitch';
 import { handleGoalsCommand, handleGoalInteraction } from './goals';
+import { handleEmojiCommand, handleEmojiAutocomplete } from './emoji';
 import { registerAcronymListeners } from './acronyms';
 import { registerHaikuListeners } from './haiku';
 
@@ -76,6 +77,25 @@ client.on('interactionCreate', (interaction) =>
         return;
       }
 
+      if (group === 'symbols') {
+        const userIsModerator = interaction.memberPermissions?.has(
+          PermissionFlagsBits.ModerateMembers
+        );
+        const botCanManageEmojis =
+          interaction.guild?.members.me?.permissions.has(
+            PermissionFlagsBits.ManageGuildExpressions
+          );
+        if (!userIsModerator || !botCanManageEmojis) {
+          await interaction.reply({
+            content: !userIsModerator
+              ? 'You need moderator permissions to use this command.'
+              : 'I need the Manage Expressions permission in this server to manage symbols.',
+            ephemeral: true,
+          });
+          return;
+        }
+      }
+
       switch (group) {
         case 'kudos':
           await handleKudosCommand(interaction);
@@ -110,6 +130,10 @@ client.on('interactionCreate', (interaction) =>
         case 'goals':
           await handleGoalsCommand(interaction);
           break;
+
+        case 'symbols':
+          await handleEmojiCommand(interaction);
+          break;
       }
     } else {
       if (
@@ -122,6 +146,13 @@ client.on('interactionCreate', (interaction) =>
           await handleGoalInteraction(interaction);
         } else if (customId.startsWith('bookclub-')) {
           await handleBookClubPicksInteraction(interaction);
+        }
+      } else if (interaction.isAutocomplete()) {
+        if (
+          interaction.commandName === 'lgt' &&
+          interaction.options.getSubcommandGroup() === 'symbols'
+        ) {
+          await handleEmojiAutocomplete(interaction);
         }
       }
     }


### PR DESCRIPTION
# Manage Server Emojis, Clone From Other Servers
*This is made under the assumption that the same Bot (Discord App) is used in both LGT and LGT-NF*

---
**Files I Changed:**
`src/commands.ts`
- Added `getEmojiCommands` import
- Registered `symbols` (emojis) command group

`src/index.ts`
- Verify User is a server-mod and bot can manage server expressions
- Added conditional check for Auto-Complete interaction type, routes to emoji removal

---
**Files I Added:**
`src/emoji.ts`
- `getEmojiCommands` + Handler
- Auto-Complete Handler for Removing Emojis
- `handleCloneFrom`
  - Input server ID, Ensure Bot is member of server, if so: Import custom emojis from that server
  - Duplicates are checked by emoji name, and are disregarded
  - Response delivered quickly, updated upon completion
  - Results are broken into 3 categories: Success, Duplicates, Failed (Each shows when more than 0)
    - Any Failed or Duplicate emojis are listed out
- `handleRemove`
  - Take name entered as string, compare against custom server emojis
  - Remove exact match (max 1)

---
### PR Prerequisites:
`bun run lint`* and `bun run typecheck` pass

***For Windows**
I had to change the `prettierrc` file to include `"endOfLine": "auto"` to pass checks
(Reverted back before pushing, though)


## For Testing
- Bot needs to be a member in both servers to run `import-from`
- Bot needs to have `Manage Expressions` Permissions in the server from which it's being called
- User needs to be a Mod in the server to which they want to import the emojis

*Known Display Issue*
- Typing a command, inputting an entry, navigating to a different channel or server (leaving the command in the textarea), returning and clicking enter
  - A Second Input box appears and is treated as the only one (not sure of a fix for this?)

---

**Feature I can probably add if this is going in the right direction**
- Importing individual emojis instead of all or none
